### PR TITLE
修复空指针异常

### DIFF
--- a/app/src/main/java/com/tamic/retrofitclient/net/PersistentCookieStore.java
+++ b/app/src/main/java/com/tamic/retrofitclient/net/PersistentCookieStore.java
@@ -76,7 +76,8 @@ public class PersistentCookieStore {
 
         //讲cookies持久化到本地
         SharedPreferences.Editor prefsWriter = cookiePrefs.edit();
-        prefsWriter.putString(url.host(), TextUtils.join(",", cookies.get(url.host()).keySet()));
+        if (cookies.get(url.host()) != null && !cookies.get(url.host()).isEmpty())
+            prefsWriter.putString(url.host(), TextUtils.join(",", cookies.get(url.host()).keySet()));
         prefsWriter.putString(name, encodeCookie(new SerializableOkHttpCookies(cookie)));
         prefsWriter.apply();
     }


### PR DESCRIPTION
cookie过期且cookies没有添加过该host的其他cookie的时候，会出现空指针的异常